### PR TITLE
Release worker 0.1.3 — Email Routing self-heal

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This repository is the open-source routing Worker. The Relaybase desktop app is 
 |--|-----|
 | Latest release | https://github.com/strum-us/relaybase-worker/releases/latest |
 | Manifest | https://github.com/strum-us/relaybase-worker/releases/latest/download/worker-install-manifest.json |
-| Worker JS (0.1.2) | https://github.com/strum-us/relaybase-worker/releases/download/v0.1.2/worker.0.1.2.js |
-| Install ZIP (0.1.2) | https://github.com/strum-us/relaybase-worker/releases/download/v0.1.2/relaybase-worker-install-0.1.2.zip |
+| Worker JS (0.1.3) | https://github.com/strum-us/relaybase-worker/releases/download/v0.1.3/worker.0.1.3.js |
+| Install ZIP (0.1.3) | https://github.com/strum-us/relaybase-worker/releases/download/v0.1.3/relaybase-worker-install-0.1.3.zip |
 
 How to cut a release: [docs/RELEASE.md](./docs/RELEASE.md).
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -2,14 +2,13 @@
 
 Customer-facing Worker installs ship as **pre-built JS bundles** (not TypeScript source).
 
-Desktop and Worker share **one product semver** — always bump both together.
-First public release: **0.1.1**. Policy: sibling repo
-[`relaybase/docs/version-sync.md`](../../relaybase/docs/version-sync.md).
+**Start with the full checklist:** sibling repo [main/docs/release/workflow.md](../main/docs/release/workflow.md).
 
-**CRITICAL (Pre-launch):** Version is frozen at **`0.1.1`**. Do **NOT** bump versions for pre-launch bug fixes or repackaging. After official launch, later updates bump the **patch** only (`0.1.2`, `0.1.3`, …). There is no separate
-dev / `+local` channel. Desktop install/update uploads **only** this hosted ZIP.
+Version pairing policy: [main/docs/release/version-sync.md](../main/docs/release/version-sync.md).
 
-Desktop releases: [`relaybase/desktop/docs/release.md`](../../relaybase/desktop/docs/release.md).
+Desktop releases: [main/desktop/docs/release.md](../main/desktop/docs/release.md).
+
+Patch-only channel after **0.1.1** (`0.1.2`, `0.1.3`, …). No separate dev / `+local` channel.
 
 ---
 
@@ -19,16 +18,17 @@ Every Worker release uses a dedicated branch. Do **not** bump versions or
 commit download artifacts straight on `main`.
 
 ```text
-release-worker-<semver>    # e.g. release-worker-0.1.1
+release-worker-<semver>    # e.g. release-worker-0.1.3
 ```
 
 1. `git checkout main && git pull`
 2. `git checkout -b release-worker-X.Y.Z`
-3. All release work on that branch
-4. Push branch
-5. Merge into `main`, push `main`
-6. Tag `vX.Y.Z` and publish a GitHub Release (`pnpm run publish:github`)
-7. Keep `release-worker-X.Y.Z` on the remote
+3. All release work on that branch (version, notes, README links)
+4. Push branch → PR → merge into `main`
+5. **`pnpm run publish:github`** — creates tag `vX.Y.Z` and GitHub Release assets
+6. Keep `release-worker-X.Y.Z` on the remote
+
+**Do not stop after `pack:customer-install`.** The desktop app reads the GitHub Release manifest. Without `publish:github`, Settings → Worker version stays on the previous release.
 
 ---
 
@@ -36,7 +36,9 @@ release-worker-<semver>    # e.g. release-worker-0.1.1
 
 ### 1. Version bump
 
-Set the version in [`package.json`](../package.json) **and** bump Desktop in the sibling `relaybase` repo to the same semver — see [`relaybase/docs/version-sync.md`](../../relaybase/docs/version-sync.md).
+Set the version in [`package.json`](../package.json) and `wrangler.toml` → `WORKER_VERSION`.
+
+When desktop also ships, bump desktop in sibling `main/` and note pairing in desktop release notes.
 
 ### 2. Release notes (required)
 
@@ -58,18 +60,7 @@ date: YYYY-MM-DD
 
 `pack-customer-install.mjs` **fails** if this file is missing.
 
-### 3. Pack
-
-```bash
-pnpm run pack:customer-install
-```
-
-Pack runs `build:bundle` and writes versioned artifacts. Manifest `zipUrl` /
-`workerJsUrl` point at GitHub Releases
-(`https://github.com/strum-us/relaybase-worker/releases/download/vX.Y.Z/…`).
-Override the output directory with `RELAYBASE_DOWNLOADS_DIR`.
-
-### 4. Publish GitHub Release
+### 3. Publish GitHub Release
 
 From this repo (requires `gh` auth):
 
@@ -77,7 +68,7 @@ From this repo (requires `gh` auth):
 pnpm run publish:github
 ```
 
-This creates tag `vX.Y.Z` (if needed) and uploads:
+This runs `pack:customer-install`, then creates/updates release `vX.Y.Z` with:
 
 - `worker.X.Y.Z.js`
 - `relaybase-worker-install-X.Y.Z.zip`
@@ -86,10 +77,18 @@ This creates tag `vX.Y.Z` (if needed) and uploads:
 
 Pushing a `v*` tag also runs `.github/workflows/release.yml`.
 
-### 5. Verify
+Local pack only (no GitHub):
 
 ```bash
-curl -sL https://github.com/strum-us/relaybase-worker/releases/latest/download/worker-install-manifest.json
+pnpm run pack:customer-install
+```
+
+Output under `dist/` (gitignored). Use for smoke tests, not customer delivery.
+
+### 4. Verify
+
+```bash
+curl -sL https://github.com/strum-us/relaybase-worker/releases/latest/download/worker-install-manifest.json | jq .version
 curl -sI https://github.com/strum-us/relaybase-worker/releases/download/vX.Y.Z/worker.X.Y.Z.js | grep -i HTTP
 ```
 
@@ -118,9 +117,9 @@ Public URLs (after publish):
 
 ## Desktop behavior
 
-- **Fresh install:** downloads latest ZIP from manifest → deploy → stores `workerVersion` in `~/.relaybase/workspace.json`.
-- **Startup banner:** compares stored version to manifest; prompts update.
-- **Settings → Cloudflare:** manual check + “Update Worker” re-deploy.
+- **Fresh install:** downloads latest ZIP from manifest → deploy → stores `workerVersion` in workspace config.
+- **Settings → Worker version:** compares installed version to GitHub manifest; **Update Worker** redeploys.
+- Update offered only when manifest version **>** installed Worker and **≤** desktop app version.
 
 ## Local overrides
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relaybase-worker",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "MIT",
   "packageManager": "pnpm@9.12.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "deploy": "node scripts/deploy.mjs",
     "build:bundle": "wrangler deploy --dry-run --outdir dist/worker-build --config wrangler.bundle.toml",
     "typecheck": "tsc --noEmit",
-    "test": "node --test --experimental-strip-types src/lib/mobile-config.test.ts src/lib/d1-migrations.test.ts src/lib/mail/local-deliver.test.ts src/lib/owner-tokens.test.ts src/lib/owner-auth-reset.test.ts src/lib/sending-health.test.ts src/lib/sending-onboard.test.ts src/lib/cloudflare-config.test.ts src/lib/cloudflare-account.test.ts src/lib/cloudflare-zones.test.ts src/lib/cloudflare-client-zones.test.ts src/lib/mime-parse.test.ts src/lib/cloudflare-probe.test.ts src/lib/mx-apex-dns.test.ts",
+    "test": "node --test --experimental-strip-types src/lib/mobile-config.test.ts src/lib/d1-migrations.test.ts src/lib/mail/local-deliver.test.ts src/lib/owner-tokens.test.ts src/lib/owner-auth-reset.test.ts src/lib/sending-health.test.ts src/lib/sending-onboard.test.ts src/lib/cloudflare-config.test.ts src/lib/cloudflare-account.test.ts src/lib/cloudflare-zones.test.ts src/lib/cloudflare-client-zones.test.ts src/lib/mime-parse.test.ts src/lib/cloudflare-probe.test.ts src/lib/mx-apex-dns.test.ts src/lib/inbound-routing.test.ts",
     "pack:customer-install": "node scripts/pack-customer-install.mjs",
     "publish:github": "bash scripts/publish-github-release.sh",
     "copy:mailbox-r2": "node scripts/copy-mailbox-r2.mjs",

--- a/release-notes/0.1.3.md
+++ b/release-notes/0.1.3.md
@@ -1,0 +1,15 @@
+---
+date: 2026-09-09
+---
+
+# Relaybase Worker 0.1.3
+
+## Highlights
+- Email Routing self-heal for orphaned disabled rules after Worker script uploads
+- Dashboard routing health checks and manual repair endpoint
+
+## Changes
+- Add `GET/POST /console/domains/routing(/repair)` for routing status and repair
+- Run a 15-minute cron that re-enables disabled literal-To Email Routing rules
+- Fix `reenableDisabledWorkerRules` to repair orphaned rules not tied to registered addresses
+- Log routing repair events as `routing_repair` in ops logs

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import app from "./app";
 import { handleInboundEmail } from "./inbound";
 import { runAudienceCron } from "./lib/catalog-audience";
 import { runInboundIndexCron } from "./lib/inbound-index-cron";
+import { runRoutingRepairCron } from "./lib/routing-repair-cron";
 import { enqueueInboundEvent } from "./lib/inbound-events";
 import { recordOpsLog } from "./lib/ops-logs";
 import { deliverWebhooks } from "./lib/webhooks";
@@ -31,6 +32,11 @@ export default {
     ctx.waitUntil(
       runInboundIndexCron(env).catch((error) => {
         console.error("Inbound index cron failed", error);
+      }),
+    );
+    ctx.waitUntil(
+      runRoutingRepairCron(env).catch((error) => {
+        console.error("Routing repair cron failed", error);
       }),
     );
   },

--- a/src/lib/inbound-routing.test.ts
+++ b/src/lib/inbound-routing.test.ts
@@ -1,0 +1,152 @@
+// @ts-ignore node:test types are not bundled under @cloudflare/workers-types
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { CloudflareClient } from "./cloudflare-client.ts";
+import { listInboundRoutingForDomains, reenableDisabledWorkerRules } from "./inbound-routing.ts";
+
+const ACCOUNT_A = "3adf03d991843094a7343eebc0a98007";
+
+function jsonOk(result: unknown): Response {
+  return new Response(JSON.stringify({ success: true, result }), {
+    status: 200,
+  });
+}
+
+describe("listInboundRoutingForDomains", () => {
+  it("flags a domain whose worker rule was left enabled:false by Cloudflare", async () => {
+    const previous = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/zones?")) {
+        return jsonOk([
+          { id: "z-ready", name: "ready.xyz", account: { id: ACCOUNT_A } },
+          { id: "z-broken", name: "broken.xyz", account: { id: ACCOUNT_A } },
+        ]);
+      }
+      if (url.includes("/email/routing/rules")) {
+        if (url.includes("z-broken")) {
+          return jsonOk([
+            {
+              id: "rule-1",
+              enabled: false,
+              matchers: [{ type: "literal", field: "to", value: "hello@broken.xyz" }],
+              actions: [{ type: "worker", value: ["relaybase-worker"] }],
+            },
+          ]);
+        }
+        return jsonOk([
+          {
+            id: "rule-2",
+            enabled: true,
+            matchers: [{ type: "literal", field: "to", value: "hello@ready.xyz" }],
+            actions: [{ type: "worker", value: ["relaybase-worker"] }],
+          },
+        ]);
+      }
+      if (url.includes("/email/routing")) {
+        return jsonOk({ enabled: true });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    try {
+      const cf = new CloudflareClient({ accountId: ACCOUNT_A, apiToken: "tok" });
+      const results = await listInboundRoutingForDomains(cf, ["ready.xyz", "broken.xyz"]);
+
+      const ready = results.find((r) => r.domain === "ready.xyz");
+      const broken = results.find((r) => r.domain === "broken.xyz");
+      assert.ok(ready && !("error" in ready));
+      assert.ok(broken && !("error" in broken));
+      if ("rules" in ready! && "rules" in broken!) {
+        assert.deepEqual(
+          ready.rules.map((r) => r.enabled),
+          [true],
+        );
+        assert.deepEqual(
+          broken.rules.map((r) => r.enabled),
+          [false],
+        );
+        assert.equal(broken.rules[0]?.action, "worker");
+      }
+    } finally {
+      globalThis.fetch = previous;
+    }
+  });
+
+  it("captures a per-domain error instead of failing the whole batch", async () => {
+    const previous = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/zones?")) {
+        return jsonOk([]);
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    try {
+      const cf = new CloudflareClient({ accountId: ACCOUNT_A, apiToken: "tok" });
+      const results = await listInboundRoutingForDomains(cf, ["missing.xyz"]);
+      assert.equal(results.length, 1);
+      assert.ok("error" in results[0]!);
+      assert.match((results[0] as { error: string }).error, /Could not resolve/);
+    } finally {
+      globalThis.fetch = previous;
+    }
+  });
+});
+
+describe("reenableDisabledWorkerRules", () => {
+  it("re-enables a disabled worker rule even for an address no longer registered", async () => {
+    const previous = globalThis.fetch;
+    const putBodies: unknown[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/zones?")) {
+        return jsonOk([{ id: "z-1", name: "orphan.xyz", account: { id: ACCOUNT_A } }]);
+      }
+      if (url.includes("/email/routing/rules/rule-orphan")) {
+        putBodies.push(init?.body ? JSON.parse(String(init.body)) : null);
+        return jsonOk({
+          id: "rule-orphan",
+          enabled: true,
+          matchers: [{ type: "literal", field: "to", value: "old@orphan.xyz" }],
+          actions: [{ type: "worker", value: ["relaybase-worker"] }],
+        });
+      }
+      if (url.includes("/email/routing/rules")) {
+        return jsonOk([
+          {
+            id: "rule-orphan",
+            enabled: false,
+            matchers: [{ type: "literal", field: "to", value: "old@orphan.xyz" }],
+            actions: [{ type: "worker", value: ["relaybase-worker"] }],
+          },
+          {
+            id: "rule-drop",
+            enabled: false,
+            matchers: [{ type: "literal", field: "to", value: "muted@orphan.xyz" }],
+            actions: [{ type: "drop" }],
+          },
+        ]);
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    try {
+      const cf = new CloudflareClient({ accountId: ACCOUNT_A, apiToken: "tok" });
+      const result = await reenableDisabledWorkerRules(cf, "orphan.xyz");
+
+      // Only the disabled `worker` rule is touched — the disabled `drop` rule
+      // (an intentionally muted address) is left alone.
+      assert.deepEqual(
+        result.reenabled.map((r) => r.address),
+        ["old@orphan.xyz"],
+      );
+      assert.equal(putBodies.length, 1);
+      assert.equal((putBodies[0] as { enabled: boolean }).enabled, true);
+    } finally {
+      globalThis.fetch = previous;
+    }
+  });
+});

--- a/src/lib/inbound-routing.ts
+++ b/src/lib/inbound-routing.ts
@@ -1,4 +1,4 @@
-import { CloudflareClient } from "./cloudflare-client";
+import { CloudflareClient } from "./cloudflare-client.ts";
 import {
   isApexMxOwnerName,
   isCloudflareMxContent,
@@ -75,6 +75,34 @@ export async function listInboundRouting(
   };
 }
 
+export type InboundRoutingStatus =
+  | ListedInboundRouting
+  | { domain: string; error: string };
+
+/**
+ * Read-only snapshot for several zones at once. Per-domain failures (e.g. a
+ * domain not yet on this Cloudflare account) are captured as `{domain,
+ * error}` entries instead of rejecting the whole call.
+ */
+export async function listInboundRoutingForDomains(
+  cf: CloudflareClient,
+  domains: string[],
+): Promise<InboundRoutingStatus[]> {
+  return Promise.all(
+    domains.map(async (domain): Promise<InboundRoutingStatus> => {
+      try {
+        return await listInboundRouting(cf, domain);
+      } catch (error) {
+        return {
+          domain,
+          error:
+            error instanceof Error ? error.message : "Failed to list routing",
+        };
+      }
+    }),
+  );
+}
+
 type CfEmailRoutingRule = {
   id: string;
   enabled: boolean;
@@ -93,6 +121,57 @@ async function resolveZoneId(
     );
   }
   return zoneId;
+}
+
+export type ReenabledInboundRule = {
+  ruleId: string;
+  address: string | null;
+};
+
+export type ReenableDisabledRoutingResult = {
+  domain: string;
+  zoneId: string;
+  reenabled: ReenabledInboundRule[];
+};
+
+/**
+ * Re-enable every Email Routing rule whose action is `worker` but that
+ * Cloudflare left `enabled: false` (the post-script-upload bug), regardless
+ * of whether the rule's address is still a registered mailbox address.
+ *
+ * This is the direct fix for the root cause — `ensureInboundRouting`'s
+ * address-driven repair only touches rules for currently-registered
+ * addresses and misses an orphaned rule left over from an address that was
+ * later renamed or removed, even though that rule is still live in
+ * Cloudflare and still bouncing mail.
+ */
+export async function reenableDisabledWorkerRules(
+  cf: CloudflareClient,
+  domain: string,
+): Promise<ReenableDisabledRoutingResult> {
+  const zoneId = await resolveZoneId(cf, domain);
+  const existing = await cf.listEmailRoutingRules(zoneId);
+  const reenabled: ReenabledInboundRule[] = [];
+
+  for (const rule of existing) {
+    if (rule.enabled) continue;
+    if (!rule.actions.some((action) => action.type === "worker")) continue;
+
+    await cf.updateEmailRoutingRule(zoneId, rule.id, {
+      enabled: true,
+      actions: rule.actions,
+      matchers: rule.matchers,
+    });
+    const literal = rule.matchers.find(
+      (matcher) => matcher.type === "literal" && matcher.field === "to",
+    );
+    reenabled.push({
+      ruleId: rule.id,
+      address: literal?.value?.trim().toLowerCase() ?? null,
+    });
+  }
+
+  return { domain, zoneId, reenabled };
 }
 
 function matchesAddress(

--- a/src/lib/ops-logs.ts
+++ b/src/lib/ops-logs.ts
@@ -1,6 +1,6 @@
 import type { D1Database } from "@cloudflare/workers-types";
 
-export type OpsLogKind = "send" | "bounce" | "api_error" | "inbound";
+export type OpsLogKind = "send" | "bounce" | "api_error" | "inbound" | "routing_repair";
 export type OpsLogSource = "compose" | "api" | "broadcast" | "inbound" | "mobile";
 
 export type OpsLogEntry = {

--- a/src/lib/routing-repair-cron.ts
+++ b/src/lib/routing-repair-cron.ts
@@ -1,0 +1,62 @@
+/**
+ * Periodic Email Routing self-heal.
+ *
+ * Cloudflare can leave a domain's literal-To Email Routing rules
+ * `enabled: false` after a Worker script upload, which bounces inbound mail
+ * with `550 5.1.1 Address not found`. This cron re-enables any such rule
+ * directly — regardless of whether its address is still a registered
+ * mailbox address, since an orphaned rule (address renamed/removed after
+ * Cloudflare disabled it) is still live and still bouncing mail.
+ */
+import type { Env } from "../env";
+import { createAppDb } from "../../db/app";
+import { readMailbox } from "./catalog-store";
+import { createCloudflareClient } from "./cloudflare-config";
+import { listInboundRoutingForDomains, reenableDisabledWorkerRules } from "./inbound-routing";
+import { recordOpsLog } from "./ops-logs";
+
+export async function runRoutingRepairCron(env: Env): Promise<void> {
+  const appDb = createAppDb(env.RELAYBASE_DB);
+  if (!appDb) return;
+
+  const mailbox = await readMailbox(appDb);
+  const domains = mailbox.domains
+    .map((domain) => domain.trim().toLowerCase())
+    .filter(Boolean);
+  if (!domains.length) return;
+
+  let cf;
+  try {
+    cf = await createCloudflareClient(env);
+  } catch {
+    // CF_API_TOKEN not configured — nothing to repair.
+    return;
+  }
+
+  const statuses = await listInboundRoutingForDomains(cf, domains);
+  for (const status of statuses) {
+    if ("error" in status) continue;
+
+    const hasDisabledWorkerRule = status.rules.some(
+      (rule) => rule.action === "worker" && rule.enabled === false,
+    );
+    if (!hasDisabledWorkerRule) continue;
+
+    try {
+      const result = await reenableDisabledWorkerRules(cf, status.domain);
+      await recordOpsLog(env.RELAYBASE_LOGS, {
+        kind: "routing_repair",
+        ok: true,
+        domain: status.domain,
+        metaJson: JSON.stringify({ repairedRules: result.reenabled.length }),
+      });
+    } catch (error) {
+      await recordOpsLog(env.RELAYBASE_LOGS, {
+        kind: "routing_repair",
+        ok: false,
+        domain: status.domain,
+        error: error instanceof Error ? error.message : "Failed to repair routing",
+      });
+    }
+  }
+}

--- a/src/routes/console/domains.ts
+++ b/src/routes/console/domains.ts
@@ -5,8 +5,12 @@ import { createCloudflareClient } from "../../lib/cloudflare-config";
 import { createAppDb } from "../../../db/app";
 import {
   clearConflictingMxRecords,
+  ensureInboundRouting,
   findConflictingMxRecords,
+  listInboundRoutingForDomains,
   MxConflictError,
+  reenableDisabledWorkerRules,
+  type InboundRoutingResult,
   type MxConflictRecord,
 } from "../../lib/inbound-routing";
 import {
@@ -184,6 +188,78 @@ consoleDomains.delete("/", async (c) => {
     domains: listDomainSummaries(data),
     message: "Domain removed",
   });
+});
+
+// GET /console/domains/routing[?domain=] — Email Routing enablement + rule
+// status per domain, so the dashboard can flag rules Cloudflare left
+// `enabled: false` after a Worker script upload.
+consoleDomains.get("/routing", async (c) => {
+  const denied = await requireConsoleSession(c);
+  if (denied) return denied;
+
+  const mailbox = await readMailbox(createAppDb(c.env.RELAYBASE_DB));
+  const requested = c.req.query("domain")?.trim().toLowerCase();
+  const domains = requested
+    ? [requested]
+    : mailbox.domains.map((domain) => domain.trim().toLowerCase()).filter(Boolean);
+
+  try {
+    const cf = await createCloudflareClient(c.env);
+    const results = await listInboundRoutingForDomains(cf, domains);
+    return c.json({ domains: results });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to list routing";
+    return c.json({ error: message }, 502);
+  }
+});
+
+// POST /console/domains/routing/repair {domain} — turns any Email Routing
+// rule Cloudflare left `enabled: false` back on (the post-upload bug, even
+// for a rule whose address is no longer registered), then also re-applies a
+// literal-To rule for every currently-registered address (covers an address
+// that never got a rule in the first place).
+consoleDomains.post("/routing/repair", async (c) => {
+  const denied = await requireConsoleSession(c);
+  if (denied) return denied;
+
+  let body: { domain?: string };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+  const domain = normalizeDomain(body.domain ?? "");
+  if (!domain) {
+    return c.json({ error: "domain is required" }, 400);
+  }
+
+  try {
+    const cf = await createCloudflareClient(c.env);
+    const reenabled = await reenableDisabledWorkerRules(cf, domain);
+
+    const mailbox = await readMailbox(createAppDb(c.env.RELAYBASE_DB));
+    const entries = mailbox.addresses
+      .filter((address) => address.domain === domain)
+      .map((address) => ({
+        address: address.email,
+        inboundEnabled: address.inboundEnabled !== false,
+      }));
+    const result: InboundRoutingResult | null = entries.length
+      ? await ensureInboundRouting(cf, domain, entries, c.env.WORKER_SCRIPT_NAME)
+      : null;
+
+    return c.json({
+      domain,
+      zoneId: reenabled.zoneId,
+      reenabledOrphanedRules: reenabled.reenabled,
+      rules: result?.rules ?? [],
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to repair routing";
+    return c.json({ error: message }, 502);
+  }
 });
 
 export { consoleDomains };

--- a/src/routes/mail/inbox.ts
+++ b/src/routes/mail/inbox.ts
@@ -6,7 +6,7 @@ import { createAppDb } from "../../../db/app";
 import { createMailDb } from "../../../db/mail";
 import {
   ensureInboundRouting,
-  listInboundRouting,
+  listInboundRoutingForDomains,
   removeInboundWorkerRouting,
   type InboundRoutingResult,
   type RemoveInboundRoutingResult,
@@ -305,19 +305,7 @@ mailInbox.get("/routing", async (c) => {
 
   try {
     const cf = await createCloudflareClient(c.env);
-    const results = await Promise.all(
-      domains.map(async (domain) => {
-        try {
-          return await listInboundRouting(cf, domain);
-        } catch (error) {
-          return {
-            domain,
-            error:
-              error instanceof Error ? error.message : "Failed to list routing",
-          };
-        }
-      }),
-    );
+    const results = await listInboundRoutingForDomains(cf, domains);
     return c.json({ domains: results });
   } catch (error) {
     const message =

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,7 +8,7 @@ compatibility_date = "2025-06-01"
 [vars]
 WORKER_SCRIPT_NAME = "relaybase-api"
 INBOUND_BUCKET_NAME = "relaybase-mailbox"
-WORKER_VERSION = "0.1.2"
+WORKER_VERSION = "0.1.3"
 
 [triggers]
 crons = ["*/15 * * * *"]


### PR DESCRIPTION
## Summary
- Ship Worker **0.1.3** with Email Routing self-heal: routing status/repair endpoints, 15-minute cron, and fix for orphaned disabled rules
- GitHub Release **v0.1.3** published (`worker.0.1.3.js`, install ZIP, manifest)
- Update `docs/RELEASE.md` to require `publish:github` (pack alone does not update the manifest the desktop app reads)

## Test plan
- [ ] `curl -sL https://github.com/strum-us/relaybase-worker/releases/latest/download/worker-install-manifest.json | jq .version` → `0.1.3`
- [ ] Desktop **0.1.6** Settings → Worker version → Check for updates → offers upgrade to **0.1.3**
- [ ] Update Worker succeeds; `GET /health` → `version: "0.1.3"`
- [ ] `GET /console/domains/routing` and `POST .../routing/repair` re-enable disabled literal-To rules


Made with [Cursor](https://cursor.com)