### PR TITLE
Expose DESKTOP_VERSION on /health for mailbox-mode desktop update gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Connect the [Relaybase desktop app](https://relaybase.xyz): paste your Worker UR
 | `WORKER_SCRIPT_NAME` | Worker script name (default `relaybase-api`) |
 | `INBOUND_BUCKET_NAME` | R2 bucket label |
 | `WORKER_VERSION` | Reported in `/health` |
+| `DESKTOP_VERSION` | Desktop app version this Worker build is compatible with; reported in `/health` as `desktopVersion`. Gates mailbox-mode (invited/team) desktop auto-updates so a team member's app never self-updates past what the connected Worker supports. |
 
 ## API examples
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -37,6 +37,9 @@ release-worker-<semver>    # e.g. release-worker-0.1.3
 ### 1. Version bump
 
 Set the version in [`package.json`](../package.json) and `wrangler.toml` → `WORKER_VERSION`.
+Also set `wrangler.toml` → `DESKTOP_VERSION` to the desktop app version this
+Worker build is compatible with (mirrors `WORKER_VERSION`'s upkeep; reported
+in `/health` as `desktopVersion` and read back by the pack script below).
 
 When desktop also ships, bump desktop in sibling `main/` and note pairing in desktop release notes.
 

--- a/scripts/pack-customer-install.mjs
+++ b/scripts/pack-customer-install.mjs
@@ -52,6 +52,22 @@ if (!version || version === "0.0.0") {
   process.exit(1);
 }
 
+/**
+ * Read a quoted `[vars]` value (e.g. `DESKTOP_VERSION`) out of the repo's
+ * hand-maintained `wrangler.toml`. Unlike `WORKER_VERSION`, the desktop
+ * version has no `package.json` field to source from, so the packed install
+ * ZIP mirrors whatever the repo's `wrangler.toml` declares. Returns the
+ * empty string when the var is absent (packed Worker then reports
+ * `desktopVersion: "unknown"` — fail-open, never worse than no gating).
+ */
+function readWranglerVar(name) {
+  const raw = readFileSync(join(serverRoot, "wrangler.toml"), "utf8");
+  const re = new RegExp(`^\\s*${name}\\s*=\\s*"([^"]+)"`, "m");
+  const match = raw.match(re);
+  return match ? match[1].trim() : "";
+}
+const desktopVersion = readWranglerVar("DESKTOP_VERSION");
+
 const notesPath = join(serverRoot, "release-notes", `${version}.md`);
 if (!existsSync(notesPath)) {
   console.error(
@@ -120,6 +136,7 @@ compatibility_date = "2025-06-01"
 WORKER_SCRIPT_NAME = "relaybase-api"
 INBOUND_BUCKET_NAME = "relaybase-mailbox"
 WORKER_VERSION = "${version}"
+DESKTOP_VERSION = "${desktopVersion}"
 
 [triggers]
 crons = ["*/15 * * * *"]

--- a/src/app.ts
+++ b/src/app.ts
@@ -63,6 +63,7 @@ app.get("/health", async (c) => {
   return c.json({
     ok: true,
     version: c.env.WORKER_VERSION?.trim() || "unknown",
+    desktopVersion: c.env.DESKTOP_VERSION?.trim() || "unknown",
     inbound: {
       r2Configured,
       bucketName: c.env.INBOUND_BUCKET_NAME,

--- a/src/env.ts
+++ b/src/env.ts
@@ -23,4 +23,6 @@ export type Env = {
   INBOUND_BUCKET_NAME: string;
   /** Set in packed wrangler.toml [vars] at pack time. */
   WORKER_VERSION?: string;
+  /** Desktop app version this Worker build is compatible with. Reported in `/health` as `desktopVersion`; gates mailbox-mode desktop auto-updates. */
+  DESKTOP_VERSION?: string;
 };

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,6 +9,7 @@ compatibility_date = "2025-06-01"
 WORKER_SCRIPT_NAME = "relaybase-api"
 INBOUND_BUCKET_NAME = "relaybase-mailbox"
 WORKER_VERSION = "0.1.5"
+DESKTOP_VERSION = "0.1.8"
 
 [triggers]
 crons = ["*/15 * * * *"]


### PR DESCRIPTION
## Summary
- Add `DESKTOP_VERSION` to wrangler vars, `Env`, and the public `GET /health` response as `desktopVersion`.
- Thread `DESKTOP_VERSION` through `pack-customer-install.mjs` so customer install ZIPs carry the desktop ceiling alongside `WORKER_VERSION`.
- Document the new var in README and RELEASE workflow docs.

This makes the Worker the source of truth for which desktop app version mailbox-mode (invited/team) sessions may install. Workers without `DESKTOP_VERSION` report `desktopVersion: "unknown"` and fail open.

Pairs with the desktop PR in `relaybase` (`feat/mailbox-desktop-update-gate`).

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm test` (77 tests)
- [x] `pnpm run build:bundle` — bundle contains `desktopVersion` / `DESKTOP_VERSION`
- [x] `readWranglerVar("DESKTOP_VERSION")` extracts `0.1.8` from `wrangler.toml`
- [ ] Deploy dogfood Worker and verify `curl $WORKER_URL/health | jq .desktopVersion`


Made with [Cursor](https://cursor.com)